### PR TITLE
Add support for custom references path to be used with CI

### DIFF
--- a/lib/commands/compareScreenshotFromElement.js
+++ b/lib/commands/compareScreenshotFromElement.js
@@ -28,7 +28,7 @@ function retrieveCache(client, selector, customName, readDirCallback) {
           const customCache = {
             latest: path.join(customFilePath, fixedSelector, referenceFile),
             current: path.join(filepath, fixedSelector, `ref.${b}.png`),
-            filepathDiff: path.join(filepath, fixedSelector, 'diff.png'),
+            filepathDiff: path.join(filepath, fixedSelector, `diff.${b}.png`),
           };
           readDirCallback(customCache);
         }
@@ -83,9 +83,14 @@ module.exports.command = function compareScreenshotFromElement(selector, customN
           resemble(cache.current)
             .compareTo(cache.latest)
             .onComplete(data => {
-              done.call(this, {
-                imageDiff: data,
-              }, cb);
+              data.getDiffImage().pack()
+                .pipe(fs.createWriteStream(cache.filepathDiff))
+                .on('finish', () => {
+                  done.call(this, {
+                    filepathDiff: cache.filepathDiff,
+                    imageDiff: data,
+                  }, cb);
+                });
             });
         }
         retrieveCache(this, selector, customName, compareImage);

--- a/lib/commands/compareScreenshotFromElement.js
+++ b/lib/commands/compareScreenshotFromElement.js
@@ -82,8 +82,10 @@ module.exports.command = function compareScreenshotFromElement(selector, customN
           }
           resemble(cache.current)
             .compareTo(cache.latest)
-            .onComplete(() => {
-              done.call(this, { pending: 'comparison completed' }, cb);
+            .onComplete(data => {
+              done.call(this, {
+                imageDiff: data,
+              }, cb);
             });
         }
         retrieveCache(this, selector, customName, compareImage);
@@ -94,7 +96,7 @@ module.exports.command = function compareScreenshotFromElement(selector, customN
       const diffImages = retrieveCache(this, selector, customName);
 
       if (!diffImages) {
-        return done.call(this, { pending: 'Nothing to compare, skipping...' }, cb);
+        return done.call(this, { pending: 'Nothing to compare, skipping..' }, cb);
       }
 
       if (!fs.existsSync(diffImages.latest)) {

--- a/lib/commands/compareScreenshotFromElement.js
+++ b/lib/commands/compareScreenshotFromElement.js
@@ -6,19 +6,42 @@ const resemble = require('node-resemble-js');
 const fs = require('fs-extra');
 const path = require('path');
 
-function retrieveCache(client, selector, customName) {
+function retrieveCache(client, selector, customName, readDirCallback) {
   const fixedSelector = util.normalize(selector);
   const fixedName = customName ? util.normalize(customName) : client.currentTest.module;
   const filepath = path.join(client.options.screenshotsPath, fixedName);
   const options = client.options.dayguard || {};
-  const cache = util.cache(options, filepath, fixedSelector);
+  let customFilePath = filepath;
+  if (client.globals.customScreenshotsPath) {
+    customFilePath = path.join(client.globals.customScreenshotsPath, fixedName);
+  }
+  const cache = util.cache(options, customFilePath, fixedSelector);
+  if (cache && client.globals.customScreenshotsPath) {
+    const b = cache.src.length - 1;
+    const fileType = '.png'; // file extension
+    let referenceFile = '';
+    fs.readdir(path.join(customFilePath, fixedSelector), function (err, list) {
+      if (err) throw err;
+      for (let i = 0; i < list.length; i++) {
+        if (path.extname(list[i]) === fileType) {
+          referenceFile = list[i];
+          const customCache = {
+            latest: path.join(customFilePath, fixedSelector, referenceFile),
+            current: path.join(filepath, fixedSelector, `ref.${b}.png`),
+            filepathDiff: path.join(filepath, fixedSelector, 'diff.png'),
+          };
+          readDirCallback(customCache);
+        }
+      }
+    });
+  }
 
   if (cache && ((cache.src.length > 1) || options.ref)) {
     const a = options.ref ? '_ref' : (cache.src.length - 2);
     const b = cache.src.length - 1;
 
     return {
-      latest: path.join(filepath, fixedSelector, `${options.ref ? a : (`ref.${a}`)}.png`),
+      latest: path.join(customFilePath, fixedSelector, `${options.ref ? a : (`ref.${a}`)}.png`),
       current: path.join(filepath, fixedSelector, `ref.${b}.png`),
       filepathDiff: path.join(filepath, fixedSelector, `ref.${a}_${b}.png`),
     };
@@ -42,7 +65,30 @@ module.exports.command = function compareScreenshotFromElement(selector, customN
   if (typeof done !== 'function') {
     throw new TypeError('compareScreenshotFromElement() expects a valid callback');
   }
+  if (this.globals.customScreenshotsPath) {
+    return this
+      .perform((api, cb) => {
+        function compareImage(cache) {
+          if (!cache) {
+            return done.call(this, { pending: 'Nothing to compare, skipping...' }, cb);
+          }
 
+          if (!fs.existsSync(cache.latest)) {
+            throw new Error(`Missing latest reference ${cache.latest}`);
+          }
+
+          if (!fs.existsSync(cache.current)) {
+            throw new Error(`Missing current reference ${cache.current}`);
+          }
+          resemble(cache.current)
+            .compareTo(cache.latest)
+            .onComplete(() => {
+              done.call(this, { pending: 'comparison completed' }, cb);
+            });
+        }
+        retrieveCache(this, selector, customName, compareImage);
+      });
+  }
   return this
     .perform((api, cb) => {
       const diffImages = retrieveCache(this, selector, customName);
@@ -58,7 +104,6 @@ module.exports.command = function compareScreenshotFromElement(selector, customN
       if (!fs.existsSync(diffImages.current)) {
         throw new Error(`Missing current reference ${diffImages.current}`);
       }
-
       resemble(diffImages.current)
         .compareTo(diffImages.latest)
         .onComplete(data => {


### PR DESCRIPTION
1) Run the tests as usually to generate your references
2) Add `"globals": {"customScreenshotsPath":"yourPath"}` to your nightwatch.json the path of your image references. e.g.
"test_settings": {
    "yourEnvironment": {
      "globals": {
        "customScreenshotsPath": "referenceScreenshots/"}}}
3) Run the tests again against the static references